### PR TITLE
fix inconsistent naming and add unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "@author.io/shell",
   "version": "1.1.7",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@author.io/arg": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@author.io/arg/-/arg-1.2.5.tgz",
+      "integrity": "sha512-i+6F2ViIojVDqs+GS6Att/79SPDvdTijYzNg0VmNXF/03MIPWKnVwyRLOCpTx0pRjZNa3WQJwGZ3vqGN36lG1w=="
+    }
+  }
 }

--- a/test/unit/01-sanity/01-sanity.js
+++ b/test/unit/01-sanity/01-sanity.js
@@ -8,6 +8,7 @@ test('Sanity Check - Shell', t => {
   })
 
   t.ok(shell instanceof Shell, 'Basic shell instantiates correctly.')
+
   t.end()
 })
 
@@ -31,27 +32,19 @@ test('Sanity Check - Command', t => {
     commands: [
       mirror,
       {
-        name: 'find',
-        description: 'Search metadoc for all the things.',
-        alias: 'search',
-        flags: {
-          x: {
-            type: 'string',
-            required: true
-          }
-        },
-        handler(data, cb) {
-          console.log(data)
-          console.log(`Mirroring input: ${data.input}`)
-
-          cb && cb()
-        }
-        // Subcommands are supported
-        // , commands: [...]
+        name: 'test',
+        description: 'Test command which has no custom handler.'
       }
     ]
   })
 
   t.ok(CLI instanceof Shell, 'Shell initialized with commands successfully.')
+
+  let defaultHandlerFires = false
+
+  CLI.exec('test', data => defaultHandlerFires = true)
+
+  t.ok(defaultHandlerFires, 'Default handler fires.')
+
   t.end()
 })


### PR DESCRIPTION
There was an inconsistency in the naming of the default handler function, `defaultMethod` in some places and `defaultHandler` in others. This branch standardizes them all to `defaultHandler` and adds unit tests.